### PR TITLE
Move m2 and m3  …

### DIFF
--- a/kotunil/src/commonMain/kotlin/eu/sirotin/kotunil/specialunits/NonSiUnits.kt
+++ b/kotunil/src/commonMain/kotlin/eu/sirotin/kotunil/specialunits/NonSiUnits.kt
@@ -37,20 +37,6 @@ import kotlin.math.PI
 import kotlin.math.pow
 
 /**
- * Square metre
- */
-@JsExport
-@JvmField
-val m2 = m * m
-
-/**
- * Cubic metre (volume)
- */
-@JsExport
-@JvmField
-val m3 = m2 * m
-
-/**
  * Minute (time)
  */
 val Number.min: Second

--- a/kotunil/src/commonMain/kotlin/eu/sirotin/kotunil/specialunits/SpecialBaseUnits.kt
+++ b/kotunil/src/commonMain/kotlin/eu/sirotin/kotunil/specialunits/SpecialBaseUnits.kt
@@ -24,6 +24,8 @@ package eu.sirotin.kotunil.specialunits
 
 import eu.sirotin.kotunil.base.Kilogram
 import eu.sirotin.kotunil.base.kg
+import eu.sirotin.kotunil.base.m
+import eu.sirotin.kotunil.core.times
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlin.jvm.JvmField
@@ -44,3 +46,19 @@ val Number.g: Kilogram
 @JsName("g")
 @JvmField()
 val g = 0.001.kg
+
+
+/**
+ * Square metre
+ */
+@JsExport
+@JvmField
+val m2 = m * m
+
+/**
+ * Cubic metre (volume)
+ */
+@JsExport
+@JvmField
+val m3 = m2 * m
+


### PR DESCRIPTION
… since m2 is used in derived units and NonSiUnits uses Joule which is in derived units, resulting in a static circular dependency.
Also see #50 